### PR TITLE
Add installation instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ It’s implemented as a `homebrew` [external command](https://github.com/Homebre
 [![Coverage Status](https://img.shields.io/coveralls/caskroom/homebrew-cask.svg)](https://coveralls.io/r/caskroom/homebrew-cask)
 [![Join the chat at https://gitter.im/caskroom/homebrew-cask](https://img.shields.io/badge/gitter-join%20chat-blue.svg)](https://gitter.im/caskroom/homebrew-cask)
 
+## Get Cask
+
+```bash
+$ brew install caskroom/cask/brew-cask
+```
+
 ## Let’s try it!
 
 ```bash


### PR DESCRIPTION
It is useful to know how to install cask as well as use it by just reading the README.

I've copied the same language as the [main site](http://caskroom.io/) just before prompting the user to try it out.

(great extension btw, thank you for taking the time to create and nurture it)
